### PR TITLE
Update Travis CI syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
+
+os: linux
+
+dist: bionic
+
 jdk:
-  - oraclejdk8
-sudo: false
+  - openjdk8
+
 script: mvn test


### PR DESCRIPTION
- Removed the deprecated `sudo` keyword
- Replaces the deprecated `oraclejdk8` for the `openjdk8`
- Updates the linux distribution to the `bionic` (Ubuntu 18.04)  